### PR TITLE
QTL Listing on Genetic Map and Trait Pages

### DIFF
--- a/includes/TripalFields/so__qtl/so__qtl.inc
+++ b/includes/TripalFields/so__qtl/so__qtl.inc
@@ -125,13 +125,21 @@ class so__qtl extends ChadoField {
     }
 
     // Retrieve the type_ids we'll need for our query.
-    $type_id = [
-      'start' => 4360,
-      'end' => 4361,
-      'lod' => 4592,
-      'addt_effect' => 4594,
-      'parent' => 4595,
+    $type_id_obj = [
+      'start' => chado_get_cvterm(['id' => 'MAIN:start']),
+      'end' => chado_get_cvterm(['id' => 'MAIN:end']),
+      'lod' => chado_get_cvterm(['id' => 'MAIN:lod']),
+      'addt_effect' => chado_get_cvterm(['id' => 'MAIN:additive_effect']),
+      'parent' => chado_get_cvterm(['id' => 'MAIN:direction']),
     ];
+    $type_id = [];
+    foreach ($type_id_obj as $key => $obj) {
+      $type_id[$key] = 0;
+      if (is_object($obj)) {
+        $type_id[$key] = $obj->cvterm_id;
+      }
+    }
+
     // Now get the generic information for each QTL.
     $entity->{$field_name}['und'] = [];
     $query = "

--- a/includes/TripalFields/so__qtl/so__qtl.inc
+++ b/includes/TripalFields/so__qtl/so__qtl.inc
@@ -115,21 +115,33 @@ class so__qtl extends ChadoField {
         [':id' => $entity->chado_record_id])->fetchCol();
       // @debug dpm($feature_ids, 'feature_ids');
     }
+    elseif ($entity->chado_table == 'featuremap') {
+      $feature_ids = chado_query("SELECT qtl.feature_id FROM {featurepos} pos
+        LEFT JOIN {feature} qtl ON pos.feature_id=qtl.feature_id
+        WHERE qtl.type_id IN (SELECT cvterm_id FROM {cvterm} WHERE name='QTL')
+        AND pos.featuremap_id=:id",
+        [':id' => $entity->chado_record_id])->fetchCol();
+      // @debug dpm($feature_ids, 'feature_ids');
+    }
 
     // Retrieve the type_ids we'll need for our query.
     $type_id = [
       'start' => 4360,
       'end' => 4361,
+      'lod' => 4592,
+      'addt_effect' => 4594,
+      'parent' => 4595,
     ];
     // Now get the generic information for each QTL.
     $entity->{$field_name}['und'] = [];
     $query = "
       SELECT
-        qtl.name, qtl.uniquename, qtl.feature_id,
+        qtl.name, qtl.uniquename, qtl.feature_id as qtl_id,
         pos.mappos as peak_position, lg.name as linkage_group,
         pstart.value as cistart, pend.value as ciend,
-        map.name as map_name,
-        trait.name as trait_name
+        map.name as map_name, map.featuremap_id as map_id,
+        trait.name as trait_name, trait.cvterm_id as trait_id,
+        lod.value as lod, addt_effect.value as addt_effect, parent.value as parent
       FROM {feature} qtl
       LEFT JOIN {featurepos} pos ON pos.feature_id=qtl.feature_id
       LEFT JOIN {feature} lg ON lg.feature_id=pos.map_feature_id
@@ -140,24 +152,45 @@ class so__qtl extends ChadoField {
       LEFT JOIN {featuremap} map ON map.featuremap_id=pos.featuremap_id
       LEFT JOIN {feature_cvterm} fc ON fc.feature_id=qtl.feature_id
       LEFT JOIN {cvterm} trait ON trait.cvterm_id=fc.cvterm_id
-      WHERE qtl.feature_id IN (:ids)";
+      LEFT JOIN {featureprop} lod ON lod.feature_id=qtl.feature_id
+        AND lod.type_id=:lod
+      LEFT JOIN {featureprop} addt_effect ON addt_effect.feature_id=qtl.feature_id
+        AND addt_effect.type_id=:addt_effect
+      LEFT JOIN {featureprop} parent ON parent.feature_id=qtl.feature_id
+        AND parent.type_id=:parent
+      WHERE qtl.feature_id IN (:ids)
+      ORDER BY map.name ASC, trait.name ASC, lg.name ASC, pos.mappos ASC";
     $QTLs = chado_query($query,
       [':ids' => $feature_ids,
        ':start_type' => $type_id['start'],
-       ':end_type' => $type_id['end']])->fetchAll();
+       ':end_type' => $type_id['end'],
+       ':lod' => $type_id['lod'],
+       ':addt_effect' => $type_id['addt_effect'],
+       ':parent' => $type_id['parent']])->fetchAll();
     foreach ($QTLs as $qtl) {
       $entity->{$field_name}['und'][] = [
         'value' => [
+          'data:1278' => $qtl->map_name,
           'NCIT:C85496' => $qtl->trait_name,
           'schema:name' => $qtl->name,
           'data:2091' => $qtl->uniquename,
-          'data:1278' => $qtl->map_name,
           'SO:0000018' => $qtl->linkage_group,
           'MAIN:qtl_peak' => $qtl->peak_position,
           'MAIN:start' => $qtl->cistart,
           'MAIN:end' => $qtl->ciend,
+          'MAIN:lod' => $qtl->lod,
+          'MAIN:additive_effect' => $qtl->addt_effect,
+          'MAIN:direction' => $qtl->parent,
         ],
+        'chado-feature__feature_id' => $qtl->qtl_id,
+        'map_id' => $qtl->map_id,
+        'qtl_id' => $qtl->qtl_id,
+        'trait_id' => $qtl->trait_id,
       ];
+    }
+
+    if (empty($entity->{$field_name}['und'])) {
+      $entity->{$field_name}['und'][0]['value'] = '';
     }
     // @debug dpm($entity->{$field_name}['und'], $field_name);
   }

--- a/includes/TripalFields/so__qtl/so__qtl.inc
+++ b/includes/TripalFields/so__qtl/so__qtl.inc
@@ -116,22 +116,50 @@ class so__qtl extends ChadoField {
       // @debug dpm($feature_ids, 'feature_ids');
     }
 
+    // Retrieve the type_ids we'll need for our query.
+    $type_id = [
+      'start' => 4360,
+      'end' => 4361,
+    ];
     // Now get the generic information for each QTL.
     $entity->{$field_name}['und'] = [];
     $query = "
-      SELECT f.name, f.uniquename
-      FROM {feature} f 
-      WHERE feature_id IN (:ids)";
-    $QTLs = chado_query($query, [':ids' => $feature_ids])->fetchAll();
+      SELECT
+        qtl.name, qtl.uniquename, qtl.feature_id,
+        pos.mappos as peak_position, lg.name as linkage_group,
+        pstart.value as cistart, pend.value as ciend,
+        map.name as map_name,
+        trait.name as trait_name
+      FROM {feature} qtl
+      LEFT JOIN {featurepos} pos ON pos.feature_id=qtl.feature_id
+      LEFT JOIN {feature} lg ON lg.feature_id=pos.map_feature_id
+      LEFT JOIN {featureposprop} pstart ON pstart.featurepos_id=pos.featurepos_id
+        AND pstart.type_id=:start_type
+      LEFT JOIN {featureposprop} pend ON pend.featurepos_id=pos.featurepos_id
+        AND pend.type_id=:end_type
+      LEFT JOIN {featuremap} map ON map.featuremap_id=pos.featuremap_id
+      LEFT JOIN {feature_cvterm} fc ON fc.feature_id=qtl.feature_id
+      LEFT JOIN {cvterm} trait ON trait.cvterm_id=fc.cvterm_id
+      WHERE qtl.feature_id IN (:ids)";
+    $QTLs = chado_query($query,
+      [':ids' => $feature_ids,
+       ':start_type' => $type_id['start'],
+       ':end_type' => $type_id['end']])->fetchAll();
     foreach ($QTLs as $qtl) {
       $entity->{$field_name}['und'][] = [
         'value' => [
+          'NCIT:C85496' => $qtl->trait_name,
           'schema:name' => $qtl->name,
           'data:2091' => $qtl->uniquename,
+          'data:1278' => $qtl->map_name,
+          'SO:0000018' => $qtl->linkage_group,
+          'MAIN:qtl_peak' => $qtl->peak_position,
+          'MAIN:start' => $qtl->cistart,
+          'MAIN:end' => $qtl->ciend,
         ],
       ];
     }
-    //dpm($entity->{$field_name}['und'], $field_name);
+    // @debug dpm($entity->{$field_name}['und'], $field_name);
   }
 
 

--- a/includes/TripalFields/so__qtl/so__qtl.inc
+++ b/includes/TripalFields/so__qtl/so__qtl.inc
@@ -1,0 +1,198 @@
+<?php
+/**
+ * @class
+ * Purpose:
+ *
+ * Data:
+ * Assumptions:
+ */
+class so__qtl extends ChadoField {
+
+  // --------------------------------------------------------------------------
+  //                     EDITABLE STATIC CONSTANTS
+  //
+  // The following constants SHOULD be set for each descendant class.  They are
+  // used by the static functions to provide information to Drupal about
+  // the field and it's default widget and formatter.
+  // --------------------------------------------------------------------------
+
+  // The default label for this field.
+  public static $default_label = 'QTL List';
+
+  // The default description for this field.
+  public static $default_description = 'List QTL on associated Tripal Content Pages.';
+
+  // The default widget for this field.
+  public static $default_widget = 'so__qtl_widget';
+
+  // The default formatter for this field.
+  public static $default_formatter = 'so__qtl_formatter';
+
+  // The module that manages this field.
+  // If no module manages the field (IE it's added via libraries)
+  // set this to 'tripal_chado'
+  public static $module = 'tripal_qtl';
+
+  // A list of global settings. These can be accessed within the
+  // globalSettingsForm.  When the globalSettingsForm is submitted then
+  // Drupal will automatically change these settings for all fields.
+  // Once instances exist for a field type then these settings cannot be
+  // changed.
+  public static $default_settings = array(
+    'storage' => 'field_chado_storage',
+     // It is expected that all fields set a 'value' in the load() function.
+     // In many cases, the value may be an associative array of key/value pairs.
+     // In order for Tripal to provide context for all data, the keys should
+     // be a controlled vocabulary term (e.g. rdfs:type). Keys in the load()
+     // function that are supported by the query() function should be
+     // listed here.
+     'searchable_keys' => array(),
+  );
+
+  // Indicates the download formats for this field.  The list must be the
+  // name of a child class of the TripalFieldDownloader.
+  public static $download_formatters = array(
+     'TripalTabDownloader',
+     'TripalCSVDownloader',
+  );
+
+  // Provide a list of instance specific settings. These can be access within
+  // the instanceSettingsForm.  When the instanceSettingsForm is submitted
+  // then Drupal with automatically change these settings for the instance.
+  // It is recommended to put settings at the instance level whenever possible.
+  // If you override this variable in a child class be sure to replicate the
+  // term_name, term_vocab, term_accession and term_fixed keys as these are
+  // required for all TripalFields.
+  public static $default_instance_settings = array(
+    // The DATABASE name, as it appears in chado.db.  This also builds the link-out url.  In most cases this will simply be the CV name.  In some cases (EDAM) this will be the SUBONTOLOGY.
+    'term_vocabulary' => 'SO',
+    // The name of the term.
+    'term_name' => 'QTL',
+    // The unique ID (i.e. accession) of the term.
+    'term_accession' => '0000771',
+    // Set to TRUE if the site admin is not allowed to change the term
+    // type, otherwise the admin can change the term mapped to a field.
+    'term_fixed' => FALSE,
+    // Indicates if this field should be automatically attached to display
+    // or web services or if this field should be loaded separately. This
+    // is convenient for speed.  Fields that are slow should for loading
+    // should have auto_attach set to FALSE so tha their values can be
+    // attached asynchronously.
+    'auto_attach' => FALSE,
+    // The table in Chado that the instance maps to.
+    'chado_table' => '',
+    // The column of the table in Chado where the value of the field comes from.
+    'chado_column' => '',
+    // The base table.
+    'base_table' => '',
+  );
+
+  // A boolean specifying that users should not be allowed to create
+  // fields and instances of this field type through the UI. Such
+  // fields can only be created programmatically with field_create_field()
+  // and field_create_instance().
+  public static $no_ui = FALSE;
+
+  // A boolean specifying that the field will not contain any data. This
+  // should exclude the field from web services or downloads.  An example
+  // could be a quick search field that appears on the page that redirects
+  // the user but otherwise provides no data.
+  public static $no_data = FALSE;
+
+   /**
+    * @see ChadoField::load()
+    *
+    **/
+
+  public function load($entity) {
+
+    // @debug dpm($entity, 'entity');
+    $field_name = $this->instance['field_name'];
+
+    // Retrieve the QTL associated with a given trait.
+    if ($entity->chado_table == 'cvterm') {
+      $feature_ids = chado_query('SELECT feature_id FROM {feature_cvterm} WHERE cvterm_id=:id',
+        [':id' => $entity->chado_record_id])->fetchCol();
+      // @debug dpm($feature_ids, 'feature_ids');
+    }
+
+    // Now get the generic information for each QTL.
+    $entity->{$field_name}['und'] = [];
+    $query = "
+      SELECT f.name, f.uniquename
+      FROM {feature} f 
+      WHERE feature_id IN (:ids)";
+    $QTLs = chado_query($query, [':ids' => $feature_ids])->fetchAll();
+    foreach ($QTLs as $qtl) {
+      $entity->{$field_name}['und'][] = [
+        'value' => [
+          'schema:name' => $qtl->name,
+          'data:2091' => $qtl->uniquename,
+        ],
+      ];
+    }
+    //dpm($entity->{$field_name}['und'], $field_name);
+  }
+
+
+
+    /**
+    * @see ChadoField::query()
+    *
+    **/
+
+  public function query($query, $condition) {
+  }
+
+    /**
+    * @see ChadoField::queryOrder()
+    *
+    **/
+
+  public function queryOrder($query, $order) {
+  }
+
+
+    /**
+    * @see ChadoField::elementInfo()
+    *
+    **/
+
+  public function elementInfo() {
+    $field_term = $this->getFieldTermID();
+    return array(
+      $field_term => array(
+        'operations' => array('eq', 'ne', 'contains', 'starts'),
+        'sortable' => TRUE,
+        'searchable' => TRUE,
+        'label' => 'Quantitative Trait Loci (QTL)',
+        'help' => ' A polymorphic locus which contains alleles that differentially affect the expression of a continuously distributed phenotypic trait.',
+        'type' => 'xs:complexType',
+        'readonly' => TRUE,
+        'elements' => [
+          'schema:name' => [
+            'searchable' => TRUE,
+            'label' => 'QTL Name',
+            'help' => 'The published name of the quantitative trait locus.',
+            'operations' => ['eq', 'ne', 'contains', 'starts'],
+            'sortable' => TRUE,
+            'type' => 'xs:string',
+            'readonly' => TRUE,
+            'required' => FALSE,
+          ],
+          'data:2091' => [
+            'searchable' => TRUE,
+            'label' => 'QTL Accession',
+            'help' => 'The unique accession of the quantitative trait locus in this database.',
+            'operations' => ['eq', 'ne', 'contains', 'starts'],
+            'sortable' => TRUE,
+            'type' => 'xs:string',
+            'readonly' => TRUE,
+            'required' => FALSE,
+          ],
+        ],
+      ),
+    );
+  }
+
+}

--- a/includes/TripalFields/so__qtl/so__qtl_formatter.inc
+++ b/includes/TripalFields/so__qtl/so__qtl_formatter.inc
@@ -83,6 +83,12 @@ class so__qtl_formatter extends ChadoFieldFormatter {
       }
     }
 
+    // If Tripal Map is installed we would like our QTL to link to it.
+    $tripal_map = FALSE;
+    if (module_exists('tripal_map')) {
+      $tripal_map = TRUE;
+    }
+
     $header = [
       'map' => 'Genetic Map',
       'trait' => 'Trait',
@@ -92,6 +98,9 @@ class so__qtl_formatter extends ChadoFieldFormatter {
       'peak_lod' => 'Peak LOD',
       'additive_effect' => 'Additive Effect',
     ];
+    if ($tripal_map) {
+      $header['link'] = ' ';
+    }
 
     $rows = [];
     foreach ($items as $item) {
@@ -113,6 +122,17 @@ class so__qtl_formatter extends ChadoFieldFormatter {
 
         // Remove headers the admin chose to hide.
         $this->remove_columns($header, $row, $settings);
+
+        // If Tripal Map is available then link to it.
+        if ($tripal_map) {
+          $mapviewer_url = strtr('mapviewer/:map_id/:lg/:qtlname', [
+            ':map_id' => $item['map_id'],
+            ':lg' => $item['value']['SO:0000018'],
+            ':qtlname' => $item['value']['data:2091'],
+          ]);
+          $row['link'] = l('MapViewer', $mapviewer_url,
+            ['attributes' => ['target' => '_blank']]);
+        }
 
         $rows[] = $row;
       }

--- a/includes/TripalFields/so__qtl/so__qtl_formatter.inc
+++ b/includes/TripalFields/so__qtl/so__qtl_formatter.inc
@@ -16,36 +16,106 @@ class so__qtl_formatter extends ChadoFieldFormatter {
 
   // The list of default settings for this formatter.
   public static $default_settings = array(
-    'setting1' => 'default_value',
+    'title' => 'Associated quantitative trait loci (QTL).',
+    'empty' => 'There are no quantitative trait loci (QTL) asscoaited with the current page.',
+    'show_columns' => ['map', 'trait', 'qtl_name', 'pos', 'confidence_interval', 'peak_lod', 'additive_effect'],
   );
 
-   /**
-    * @see ChadoFieldFormatter::settingsForm()
-    *
-    **/
-
+  /**
+   * @see ChadoFieldFormatter::settingsForm()
+   */
   public function settingsForm($view_mode, $form, &$form_state) {
 
+    $default_settings = $this::$default_settings;
+    $display = $this->instance['display'][$view_mode];
+    $settings = $display['settings'];
+
+    // Ensure the default are set if the value is not configured.
+    foreach ($this::$default_settings as $key => $value) {
+      if (!isset($settings[$key])) {
+        $settings[$key] = $value;
+      }
+    }
+
+    $element = [];
+    $element['title'] = [
+      '#type' => 'textfield',
+      '#title' => 'Table Header',
+      '#default_value' => $settings['title'],
+    ];
+
+    $element['empty'] = [
+      '#type' => 'textfield',
+      '#title' => 'Empty text',
+      '#default_value' => $settings['empty'],
+    ];
+
+    $options = [
+      'map' => 'Genetic Map',
+      'trait' => 'Trait',
+      'qtl_name' => 'QTL Name',
+      'pos' => 'Position',
+      'confidence_interval' => 'Confidence Interval',
+      'peak_lod' => 'Peak LOD',
+      'additive_effect' => 'Additive Effect',
+    ];
+    $element['show_columns'] = [
+      '#type' => 'checkboxes',
+      '#title' => 'Show the following columns:',
+      '#options' => $options,
+      '#default_value' => $settings['show_columns'],
+    ];
+
+    return $element;
   }
 
-    /**
-    * @see ChadoFieldFormatter::View()
-    *
-    **/
-
+  /**
+   * @see ChadoFieldFormatter::View()
+   */
   public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
 
     // Get the settings
     $settings = $display['settings'];
+    // Ensure the default are set if the value is not configured.
+    foreach ($this::$default_settings as $key => $value) {
+      if (!isset($settings[$key])) {
+        $settings[$key] = $value;
+      }
+    }
 
-    $header = ['schema:name' => 'Name', 'data:2091' => 'Accession'];
+    $header = [
+      'map' => 'Genetic Map',
+      'trait' => 'Trait',
+      'qtl_name' => 'Name',
+      'pos' => 'Peak Position',
+      'confidence_interval' => 'Confidence Interval',
+      'peak_lod' => 'Peak LOD',
+      'additive_effect' => 'Additive Effect',
+    ];
+
     $rows = [];
-    // @debug dpm($items, 'items');
     foreach ($items as $item) {
-      $rows[] = [
-        'schema:name' => $item['value']['schema:name'],
-        'data:2091' => $item['value']['data:2091'],
-      ];
+      if (is_array($item['value'])) {
+        $row = [
+          'map' => $item['value']['data:1278'],
+          'trait' => $item['value']['NCIT:C85496'],
+          'qtl_name' => $item['value']['schema:name'],
+          'pos' => $item['value']['SO:0000018'] . ':' . $item['value']['MAIN:qtl_peak'],
+          'confidence_interval' => $item['value']['MAIN:start'] . '-' . $item['value']['MAIN:end'],
+          'peak_lod' => $item['value']['MAIN:lod'],
+          'additive_effect' => $item['value']['MAIN:additive_effect'] . '<br />(' . $item['value']['MAIN:direction'] . ')',
+        ];
+
+        // Make links if possible.
+        $this->replace_cell_with_link($row, 'map', 'featuremap', $item['map_id']);
+        $this->replace_cell_with_link($row, 'qtl_name', 'feature', $item['qtl_id']);
+        $this->replace_cell_with_link($row, 'trait', 'cvterm', $item['trait_id']);
+
+        // Remove headers the admin chose to hide.
+        $this->remove_columns($header, $row, $settings);
+
+        $rows[] = $row;
+      }
     }
 
     $element[0] = [
@@ -53,17 +123,64 @@ class so__qtl_formatter extends ChadoFieldFormatter {
       '#theme' => 'table',
       '#header' => $header,
       '#rows' => $rows,
+      '#empty' => $settings['empty'],
+      '#caption' => $settings['title'],
     ];
 
   }
 
-    /**
-    * @see ChadoFieldFormatter::settingsSummary()
-    *
-    **/
-
+  /**
+   * @see ChadoFieldFormatter::settingsSummary()
+   */
   public function settingsSummary($view_mode) {
-    return '';
+    $display = $this->instance['display'][$view_mode];
+    $settings = $display['settings'];
+
+    // Ensure the default are set if the value is not configured.
+    foreach ($this::$default_settings as $key => $value) {
+      if (!isset($settings[$key])) {
+        $settings[$key] = $value;
+      }
+    }
+
+    $summary = t('<strong>Title:</strong> @title<br><strong>Empty:</strong> @empty',
+      [
+        '@title' => $settings['title'],
+        '@empty' => $settings['empty'],
+      ]
+    );
+    return $summary;
   }
 
+  /**
+   * Replace the cell with a link.
+   */
+  private function replace_cell_with_link(&$row, $row_key, $table, $id) {
+
+    $entity_id = chado_get_record_entity_by_table($table, $id);
+    if ($entity_id) {
+      $row[$row_key] = l($row[$row_key], '/bio_data/'.$entity_id);
+    }
+  }
+
+  /**
+   * Remove columns which the admin has configured to be removed.
+   */
+  private function remove_columns(&$header, &$row, $settings) {
+
+    foreach ($this::$default_settings['show_columns'] as $key) {
+      if (!isset($settings['show_columns'][$key])) {
+        unset($row[$key]);
+        if (isset($header[$key])) { unset($header[$key]); }
+      }
+      else {
+        $v = $settings['show_columns'][$key];
+        if ($v === 0) {
+          unset($row[$key]);
+          if (isset($header[$key])) { unset($header[$key]); }
+        }
+      }
+    }
+
+  }
 }

--- a/includes/TripalFields/so__qtl/so__qtl_formatter.inc
+++ b/includes/TripalFields/so__qtl/so__qtl_formatter.inc
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @class
+ * Purpose:
+ *
+ * Display:
+ * Configuration:
+ */
+class so__qtl_formatter extends ChadoFieldFormatter {
+
+  // The default label for this field.
+  public static $default_label = 'QTL List';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('so__qtl');
+
+  // The list of default settings for this formatter.
+  public static $default_settings = array(
+    'setting1' => 'default_value',
+  );
+
+   /**
+    * @see ChadoFieldFormatter::settingsForm()
+    *
+    **/
+
+  public function settingsForm($view_mode, $form, &$form_state) {
+
+  }
+
+    /**
+    * @see ChadoFieldFormatter::View()
+    *
+    **/
+
+  public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
+
+    // Get the settings
+    $settings = $display['settings'];
+
+    $header = ['schema:name' => 'Name', 'data:2091' => 'Accession'];
+    $rows = [];
+    // @debug dpm($items, 'items');
+    foreach ($items as $item) {
+      $rows[] = [
+        'schema:name' => $item['value']['schema:name'],
+        'data:2091' => $item['value']['data:2091'],
+      ];
+    }
+
+    $element[0] = [
+      '#type' => 'theme',
+      '#theme' => 'table',
+      '#header' => $header,
+      '#rows' => $rows,
+    ];
+
+  }
+
+    /**
+    * @see ChadoFieldFormatter::settingsSummary()
+    *
+    **/
+
+  public function settingsSummary($view_mode) {
+    return '';
+  }
+
+}

--- a/includes/TripalFields/so__qtl/so__qtl_widget.inc
+++ b/includes/TripalFields/so__qtl/so__qtl_widget.inc
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @class
+ * Purpose:
+ *
+ * Allowing edit?
+ * Data:
+ * Assumptions:
+ */
+class so__qtl_widget extends ChadoFieldWidget {
+
+  // The default label for this field.
+  public static $default_label = 'QTL List';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('so__qtl');
+
+
+ /**
+  * @see ChadoFieldWidget::form()
+  *
+  **/
+
+  public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
+    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+  }
+
+  /**
+  * @see ChadoFieldWidget::validate()
+  *
+  **/
+  public function validate($element, $form, &$form_state, $langcode, $delta) {
+  }
+
+   /**
+  * @see ChadoFieldWidget::submit()
+  *
+  **/
+  public function submit($form, &$form_state, $entity_type, $entity, $langcode, $delta) {
+  }
+
+}

--- a/includes/tripal_qtl.fields.inc
+++ b/includes/tripal_qtl.fields.inc
@@ -83,7 +83,11 @@ function tripal_qtl_bundle_fields_info($entity_type, $bundle) {
 function tripal_qtl_bundle_instances_info($entity_type, $bundle) {
   $instances = array();
 
+  // Trait Pages
   if (isset($bundle->data_table) AND ($bundle->data_table == 'cvterm')) {
+
+    // QTL List.
+    $columns = ['map', 'qtl_name', 'pos', 'confidence_interval', 'peak_lod', 'additive_effect'];
     $field_name = 'so__qtl';
     $field_type = 'so__qtl';
     $instances[$field_name] =  array(
@@ -110,11 +114,54 @@ function tripal_qtl_bundle_instances_info($entity_type, $bundle) {
         'default' => array(
           'label' => 'hidden',
           'type' => 'so__qtl_formatter',
-          'settings' => array(),
+          'settings' => array(
+            'title' => 'The following table lists quantitative trait loci (QTL) available for the current trait.',
+            'empty' => 'There are no quantitative trait loci (QTL) asscoaited with the current trait.',
+            'show_columns' => array_combine($columns, $columns),
+          ),
         ),
       ),
     );
+  }
+  // Genetic Map Pages
+  elseif (isset($bundle->data_table) AND ($bundle->data_table == 'featuremap')) {
 
+    // QTL List.
+    $columns = ['trait', 'qtl_name', 'pos', 'confidence_interval', 'peak_lod', 'additive_effect'];
+    $field_name = 'so__qtl';
+    $field_type = 'so__qtl';
+    $instances[$field_name] =  array(
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle->name,
+      'label' => 'QTL List',
+      'description' => 'List QTL on associated Tripal Content Pages.',
+      'required' => FALSE,
+      'settings' => array(
+        'term_vocabulary' => 'SO',
+        'term_name' => 'QTL',
+        'term_accession' => '0000771',
+        'auto_attach' => FALSE,
+        'chado_table' => $bundle->data_table,
+        'chado_column' => 'organism_id',
+        'base_table' => $bundle->data_table,
+      ),
+      'widget' => array(
+        'type' => 'so__qtl_widget',
+        'settings' => array(),
+      ),
+      'display' => array(
+        'default' => array(
+          'label' => 'hidden',
+          'type' => 'so__qtl_formatter',
+          'settings' => array(
+            'title' => 'The following table lists quantitative trait loci (QTL) available for the current genetic map.',
+            'empty' => 'There are no quantitative trait loci (QTL) associated with the current genetic map.',
+            'show_columns' => array_combine($columns, $columns),
+          ),
+        ),
+      ),
+    );
   }
 
   return $instances;

--- a/includes/tripal_qtl.fields.inc
+++ b/includes/tripal_qtl.fields.inc
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @file
+ * Contains all field specific code outside the classes.
+ */
+
+/**
+ * Implements hook_bundle_fields_info().
+ *
+ * This hook tells Drupal/Tripal about your new field type. Make sure you've created the
+ * field (handles basic storage of your data), widget (provides user UI to set data),
+ * and formatter (describes display of data on Entity Page) classes. These should be
+ * located in the following directory: [your module]/includes/TripalFields/[classname].inc
+ * with one file per class. Your field name should be [cv name]__[cvterm name] and the
+ * classes should be named [field name], [field_name]_widget, [field name]_formatter
+ * for the field, widget and formatter respectively. MAKE SURE YOU'VE CLEARED THE CACHE
+ * SINCE ADDING THESE FILES so Tripal magic can find them or the following will fail.
+ *
+ * @param $entity_type
+ *   This should be 'TripalEntity' for all Tripal Content.
+ * @param $bundle
+ *   This object describes the Type of Tripal Entity (e.g. Organism or Gene) this hook is
+ *   being called for. However, since this hook creates field types (by definition not
+ *   tied to a specific Tripal Content Type (bundle)) and since a field type will only be
+ *   created if it doesn't already exist, this parameter doesn't actually matter.
+ *   NOTE: If you do need to determine the bundle in this hook, we suggest inspecting
+ *   the data_table since the label can be changed by site administrators.
+ *
+ * @return
+ *   An array of field definitions. Each field in this array will be created if it
+ *   doesn't already exist. To trigger create of fields when developing call
+ *   tripal_refresh_bundle_fields() for the specific bundle.
+ */
+function tripal_qtl_bundle_fields_info($entity_type, $bundle) {
+  $fields = array();
+
+  // First add my term.
+  tripal_insert_cvterm(array(
+    'id' => 'SO:0000771',
+    'name' => 'QTL',
+    'cv_name' => 'sequence',
+    'definition' => 'A quantitative trait locus (QTL) is a polymorphic locus which contains alleles that differentially affect the expression of a continuously distributed phenotypic trait. Usually it is a marker described by statistical association to quantitative variation in the particular phenotypic trait that is thought to be controlled by the cumulative action of alleles at multiple loci. [http://rgd.mcw.edu/tu/qtls/].',
+  ));
+
+  // Then describe the field defined by that term.
+  $field_name = 'so__qtl';
+  $field_type = 'so__qtl';
+  $fields[$field_name] = array(
+    'field_name' => $field_name,
+    'type' => $field_type,
+    'cardinality' => 0,
+    'locked' => FALSE,
+    'storage' => array(
+      'type' => 'field_chado_storage',
+    ),
+  );
+
+  return $fields;
+}
+
+/**
+ * Implements hook_bundle_instances_info().
+ *
+ * This hook tells Drupal/Tripal to create a field instance of a given field type on a
+ * specific Tripal Content type (otherwise known as the bundle). Make sure to implement
+ * hook_bundle_create_fields() to create your field type before trying to create an
+ * instance of that field.
+ *
+ * @param $entity_type
+ *   This should be 'TripalEntity' for all Tripal Content.
+ * @param $bundle
+ *   This object describes the Type of Tripal Entity (e.g. Organism or Gene) the field
+ *   instances are being created for. Thus this hook is called once per Tripal Content Type on your
+ *   site. The name of the bundle is the machine name of the type (e.g. bio_data_1) and
+ *   the label of the bundle (e.g. Organism) is what you see in the interface. Since the
+ *   label can be changed by site admin, we suggest checking the data_table to determine
+ *   if this is the entity you want to add field instances to.
+ * @return
+ *   An array of field instance definitions. This is where you can define the defaults
+ *   for any settings you use in your field. Each entry in this array will be used to
+ *   create an instance of an already existing field.
+ */
+function tripal_qtl_bundle_instances_info($entity_type, $bundle) {
+  $instances = array();
+
+  if (isset($bundle->data_table) AND ($bundle->data_table == 'cvterm')) {
+    $field_name = 'so__qtl';
+    $field_type = 'so__qtl';
+    $instances[$field_name] =  array(
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle->name,
+      'label' => 'QTL List',
+      'description' => 'List QTL on associated Tripal Content Pages.',
+      'required' => FALSE,
+      'settings' => array(
+        'term_vocabulary' => 'SO',
+        'term_name' => 'QTL',
+        'term_accession' => '0000771',
+        'auto_attach' => FALSE,
+        'chado_table' => $bundle->data_table,
+        'chado_column' => 'organism_id',
+        'base_table' => $bundle->data_table,
+      ),
+      'widget' => array(
+        'type' => 'so__qtl_widget',
+        'settings' => array(),
+      ),
+      'display' => array(
+        'default' => array(
+          'label' => 'hidden',
+          'type' => 'so__qtl_formatter',
+          'settings' => array(),
+        ),
+      ),
+    );
+
+  }
+
+  return $instances;
+}

--- a/includes/tripal_qtl.fields.inc
+++ b/includes/tripal_qtl.fields.inc
@@ -163,6 +163,52 @@ function tripal_qtl_bundle_instances_info($entity_type, $bundle) {
       ),
     );
   }
+  // Feature-based Pages (e.g. genetic map, gene, etc.)
+  /*
+  elseif (isset($bundle->data_table) AND ($bundle->data_table == 'feature')) {
+
+    // Specifically, only genetic markers.
+    $term = $bundle->term;
+    if ($term->name == 'genetic_marker') {
+      // QTL List.
+      $columns = ['map', 'trait', 'qtl_name', 'pos', 'confidence_interval', 'peak_lod'];
+      $field_name = 'so__qtl';
+      $field_type = 'so__qtl';
+      $instances[$field_name] =  array(
+        'field_name' => $field_name,
+        'entity_type' => $entity_type,
+        'bundle' => $bundle->name,
+        'label' => 'QTL List',
+        'description' => 'List QTL on associated Tripal Content Pages.',
+        'required' => FALSE,
+        'settings' => array(
+          'term_vocabulary' => 'SO',
+          'term_name' => 'QTL',
+          'term_accession' => '0000771',
+          'auto_attach' => FALSE,
+          'chado_table' => $bundle->data_table,
+          'chado_column' => 'organism_id',
+          'base_table' => $bundle->data_table,
+        ),
+        'widget' => array(
+          'type' => 'so__qtl_widget',
+          'settings' => array(),
+        ),
+        'display' => array(
+          'default' => array(
+            'label' => 'hidden',
+            'type' => 'so__qtl_formatter',
+            'settings' => array(
+              'title' => 'This following table lists quantitative trait loci (QTL) containing this genetic marker within the confidence interval.',
+              'empty' => 'There are no quantitative trait loci (QTL) associated with the current genetic marker.',
+              'show_columns' => array_combine($columns, $columns),
+            ),
+          ),
+        ),
+      );
+    }
+  }
+  */
 
   return $instances;
 }

--- a/tripal_qtl.module
+++ b/tripal_qtl.module
@@ -4,3 +4,5 @@
  * @file
  * Provides misc. hook implementations for Tripal Genetic.
  */
+
+require_once 'includes/tripal_qtl.fields.inc';


### PR DESCRIPTION
This PR adds a QTL field which will be automatically added to Genetic Map and Trait pages.

# Testing
1. Load QTL data. See #3 for instructions on how to do this.
2. Publish Genetic Map Pages: Go to Admin > Tripal Content > Publish Tripal Content and select "Genetic Map" from the drop down, submit and run job.
3. Go to the Genetic Map pages which were just created and ensure the QTL you loaded are listed.
<img width="1150" alt="Screen Shot 2019-10-28 at 4 26 53 PM" src="https://user-images.githubusercontent.com/1566301/67722827-d29afe00-f99f-11e9-98ee-07c4ddd311fe.png">

4. Create a content type for your trait CV bu going to Admin > Structure > Tripal Content Types, Add new Tripal Content Type. Select "Trait" as the term and choose your cv when prompted.
5. Publish your Trait Pages and ensure the QTL list shows up there as well.
<img width="1407" alt="Screen Shot 2019-10-28 at 4 26 36 PM" src="https://user-images.githubusercontent.com/1566301/67722806-c9aa2c80-f99f-11e9-941e-44602319a597.png">

